### PR TITLE
Improve the performance 10x on 200K events with linear structure.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@typescript-eslint/parser": "6.16.0",
         "acorn": "7.2.0",
         "aphrodite": "2.1.0",
+        "dynamic-typed-array": "^0.2.1",
         "esbuild": "0.24.2",
         "eslint": "8.0.0",
         "eslint-plugin-prettier": "5.1.2",
@@ -3726,6 +3727,17 @@
       "dev": true,
       "dependencies": {
         "webidl-conversions": "^4.0.2"
+      }
+    },
+    "node_modules/dynamic-typed-array": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/dynamic-typed-array/-/dynamic-typed-array-0.2.1.tgz",
+      "integrity": "sha512-7cPkW8tUE2oHwyypNgnXHchI7kbTBwvl5o/g5/3ZqvgjFHBRyGx09ZZzOHysEr9+jjVmo5amsia08QNIrY6wig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.4.5",
+        "npm": ">=2.15.5"
       }
     },
     "node_modules/ecc-jsbn": {
@@ -13664,6 +13676,12 @@
       "requires": {
         "webidl-conversions": "^4.0.2"
       }
+    },
+    "dynamic-typed-array": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/dynamic-typed-array/-/dynamic-typed-array-0.2.1.tgz",
+      "integrity": "sha512-7cPkW8tUE2oHwyypNgnXHchI7kbTBwvl5o/g5/3ZqvgjFHBRyGx09ZZzOHysEr9+jjVmo5amsia08QNIrY6wig==",
+      "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@typescript-eslint/parser": "6.16.0",
     "acorn": "7.2.0",
     "aphrodite": "2.1.0",
+    "dynamic-typed-array": "^0.2.1",
     "esbuild": "0.24.2",
     "eslint": "8.0.0",
     "eslint-plugin-prettier": "5.1.2",

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -2,6 +2,11 @@ import * as esbuild from 'esbuild'
 import {buildOptions, generateIndexHtml} from './esbuild-shared'
 
 async function main() {
+  process.on('SIGINT', () => {
+    console.log('Received SIGINT. Shutting down gracefully...')
+    process.exit(0) // Ensure the process exits gracefully
+  })
+
   const outdir = 'dist'
   let ctx = await esbuild.context({
     ...buildOptions,

--- a/src/gl/flamechart-renderer.ts
+++ b/src/gl/flamechart-renderer.ts
@@ -18,8 +18,6 @@ interface RangeTreeNode {
 }
 
 class RangeTreeLeafNode implements RangeTreeNode {
-  private children: RangeTreeNode[] = []
-
   constructor(
     private batch: RectangleBatch,
     private bounds: Rect,
@@ -36,7 +34,7 @@ class RangeTreeLeafNode implements RangeTreeNode {
     return this.batch.getRectCount()
   }
   getChildren() {
-    return this.children
+    return []
   }
   getParity() {
     return this.numPrecedingRectanglesInRow % 2

--- a/src/import/instruments.ts
+++ b/src/import/instruments.ts
@@ -105,7 +105,7 @@ function getWeight(deepCopyRow: any): number {
 
 // Import from a deep copy made of a profile
 export function importFromInstrumentsDeepCopy(contents: TextFileContent): Profile {
-  const profile = new CallTreeProfileBuilder()
+  const profile = new CallTreeProfileBuilder(0, 0)
   const rows = parseTSV<PastedTimeProfileRow | PastedAllocationsProfileRow>(contents)
 
   const stack: FrameInfoWithWeight[] = []
@@ -518,7 +518,7 @@ export function importThreadFromInstrumentsTrace(args: {
   const backtraceIDtoStack = new Map<number, FrameInfo[]>()
   samples = samples.filter(s => s.threadID === threadID)
 
-  const profile = new StackListProfileBuilder(lastOf(samples)!.timestamp)
+  const profile = new StackListProfileBuilder(lastOf(samples)!.timestamp, 0)
   profile.setName(`${fileName} - thread ${threadID}`)
 
   function appendRecursive(k: number, stack: FrameInfo[]) {

--- a/src/import/utils.ts
+++ b/src/import/utils.ts
@@ -1,5 +1,6 @@
 import * as pako from 'pako'
 import {JSON_parse} from 'uint8array-json-parser'
+import {internAllStrings} from '../lib/utils'
 
 export interface ProfileDataSource {
   name(): Promise<string>
@@ -60,7 +61,7 @@ function permissivelyParseJSONString(content: string) {
       content += ']'
     }
   }
-  return JSON.parse(content)
+  return internAllStrings(JSON.parse(content))
 }
 
 function permissivelyParseJSONUint8Array(byteArray: Uint8Array) {
@@ -98,7 +99,7 @@ function permissivelyParseJSONUint8Array(byteArray: Uint8Array) {
       byteArray = newByteArray
     }
   }
-  return JSON_parse(byteArray)
+  return internAllStrings(JSON_parse(byteArray))
 }
 
 export class BufferBackedTextFileContent implements TextFileContent {

--- a/src/import/utils.ts
+++ b/src/import/utils.ts
@@ -254,14 +254,12 @@ export class MaybeCompressedDataReader implements ProfileDataSource {
 
   static fromFile(file: File): MaybeCompressedDataReader {
     const maybeCompressedDataPromise: Promise<ArrayBuffer> = new Promise(resolve => {
-      let reader: FileReader | null = new FileReader()
+      let reader = new FileReader()
       reader.addEventListener('loadend', () => {
-        if (!(reader?.result instanceof ArrayBuffer)) {
+        if (!(reader.result instanceof ArrayBuffer)) {
           throw new Error('Expected reader.result to be an instance of ArrayBuffer')
         }
-        let ans = reader?.result
-        reader = null
-        resolve(ans)
+        resolve(reader.result)
       })
       reader.readAsArrayBuffer(file)
     })

--- a/src/import/utils.ts
+++ b/src/import/utils.ts
@@ -254,12 +254,14 @@ export class MaybeCompressedDataReader implements ProfileDataSource {
 
   static fromFile(file: File): MaybeCompressedDataReader {
     const maybeCompressedDataPromise: Promise<ArrayBuffer> = new Promise(resolve => {
-      const reader = new FileReader()
+      let reader: FileReader | null = new FileReader()
       reader.addEventListener('loadend', () => {
-        if (!(reader.result instanceof ArrayBuffer)) {
+        if (!(reader?.result instanceof ArrayBuffer)) {
           throw new Error('Expected reader.result to be an instance of ArrayBuffer')
         }
-        resolve(reader.result)
+        let ans = reader?.result
+        reader = null
+        resolve(ans)
       })
       reader.readAsArrayBuffer(file)
     })

--- a/src/lib/file-format.ts
+++ b/src/lib/file-format.ts
@@ -102,7 +102,7 @@ function importSpeedscopeProfile(
   function importEventedProfile(evented: FileFormat.EventedProfile) {
     const {startValue, endValue, events} = evented
 
-    const profile = new CallTreeProfileBuilder(endValue - startValue)
+    const profile = new CallTreeProfileBuilder(endValue - startValue, events.length)
     setCommonProperties(profile)
 
     const frameInfos: FrameInfo[] = frames.map((frame, i) => ({key: i, ...frame}))
@@ -146,7 +146,7 @@ function importSpeedscopeProfile(
 
   function importSampledProfile(sampled: FileFormat.SampledProfile) {
     const {startValue, endValue, samples, weights} = sampled
-    const profile = new StackListProfileBuilder(endValue - startValue)
+    const profile = new StackListProfileBuilder(endValue - startValue, samples.length)
     setCommonProperties(profile)
 
     const frameInfos: FrameInfo[] = frames.map((frame, i) => ({key: i, ...frame}))

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -1,4 +1,4 @@
-import {lastOf, KeyedSet, DynamicBitset} from './utils'
+import {lastOf, KeyedSet, DynamicBitset, StringPool} from './utils'
 import {ValueFormatter, RawValueFormatter} from './value-formatters'
 import {FileFormat} from './file-format-spec'
 // @ts-ignore
@@ -74,9 +74,17 @@ export class Frame extends HasWeights {
 
   private constructor(info: FrameInfo) {
     super()
-    this.key = info.key
-    this.name = info.name
-    this.file = info.file
+    if (typeof info.key === 'string') {
+      this.key = StringPool.intern(info.key)
+    } else {
+      this.key = info.key
+    }
+    this.name = StringPool.intern(info.name)
+    if (typeof info.file === 'string') {
+      this.file = StringPool.intern(info.file)
+    } else {
+      this.file = info.file
+    }
     this.line = info.line
     this.col = info.col
     this.index = Frame.selfWeights.size()

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -144,8 +144,9 @@ export class CallTreeNode extends HasWeights {
     CallTreeNode.frozens.push(false)
   }
 
-  childByFrame = (frame: Frame): CallTreeNode | null =>
-    this.frame2child ? this.frame2child.get(frame) : null
+  childByFrame(frame: Frame): CallTreeNode | null {
+    return this.frame2child ? this.frame2child.get(frame) : null
+  }
 
   regFrameToChild(frame: Frame, child: CallTreeNode) {
     if (!this.frame2child) {
@@ -157,8 +158,9 @@ export class CallTreeNode extends HasWeights {
     this.lazyChildren.push(child)
   }
 
-  getChildren = (): CallTreeNode[] =>
-    this.lazyChildren ? this.lazyChildren : CallTreeNode.fakeChildren
+  getChildren(): CallTreeNode[] {
+    return this.lazyChildren ? this.lazyChildren : CallTreeNode.fakeChildren
+  }
 
   getTotalWeight(): number {
     return CallTreeNode.totalWeights.get(this.index)

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -115,7 +115,7 @@ export class CallTreeNode extends HasWeights {
   // soa = Structure Of Arrays
   private static frozens = new DynamicBitset()
 
-  private index: number = -1
+  private index: number
 
   private lazyChildren: CallTreeNode[] | null = null
   private frame2child: RBTree<Frame, CallTreeNode> = null
@@ -217,7 +217,7 @@ export class Profile {
     private capacity: number,
   ) {
     this.totalWeight = totalWeight
-    this.smartWeights = new DynamicTypedArray<Float32Array>(Float32Array, capacity)
+    this.smartWeights = new DynamicTypedArray<Float32Array>(Float32Array)
   }
 
   shallowClone(): Profile {
@@ -337,7 +337,8 @@ export class Profile {
       }
 
       prevStack = prevStack.concat(toOpen)
-      value += this.smartWeights.get(sampleIndex++)
+      value += this.smartWeights.get(sampleIndex)
+      sampleIndex++
     }
 
     // Close frames that are open at the end of the trace

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -195,8 +195,8 @@ export class Profile {
   //
   // The "grouped" call tree is one in which each node has at most one child per
   // frame. Nodes are ordered in decreasing order of weight
-  protected appendOrderCalltreeRoot: CallTreeNode
-  protected groupedCalltreeRoot: CallTreeNode
+  protected appendOrderCalltreeRoot: CallTreeNode = new CallTreeNode(Frame.root, null)
+  protected groupedCalltreeRoot: CallTreeNode = new CallTreeNode(Frame.root, null)
 
   public getAppendOrderCalltreeRoot() {
     return this.appendOrderCalltreeRoot
@@ -217,8 +217,6 @@ export class Profile {
     private capacity: number,
   ) {
     this.totalWeight = totalWeight
-    this.appendOrderCalltreeRoot = new CallTreeNode(Frame.root, null)
-    this.groupedCalltreeRoot = new CallTreeNode(Frame.root, null)
     this.smartWeights = new DynamicTypedArray<Float32Array>(Float32Array, capacity)
   }
 
@@ -625,7 +623,7 @@ export class StackListProfileBuilder extends Profile {
       }
     }
     let totSmartWeights: number = 0
-    this.smartWeights.forEach(value => {
+    this.smartWeights.forEach((value, index) => {
       totSmartWeights += value
     })
     this.totalWeight = Math.max(this.totalWeight, totSmartWeights)

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -1,6 +1,7 @@
 import {lastOf, KeyedSet} from './utils'
 import {ValueFormatter, RawValueFormatter} from './value-formatters'
 import {FileFormat} from './file-format-spec'
+import RBTree from 'functional-red-black-tree'
 
 export interface FrameInfo {
   key: string | number
@@ -84,7 +85,7 @@ export class Frame extends HasWeights {
 
 export class CallTreeNode extends HasWeights {
   children: CallTreeNode[] = []
-  frame2child: Map<Frame, CallTreeNode> = new Map<Frame, CallTreeNode>()
+  frame2child: RBTree<Frame, CallTreeNode> = new RBTree<Frame, CallTreeNode>()
 
   isRoot() {
     return this.frame === Frame.root
@@ -460,7 +461,7 @@ export class StackListProfileBuilder extends Profile {
         const parent = node
         node = new CallTreeNode(frame, node)
         parent.children.push(node)
-        parent.frame2child.set(frame, node)
+        parent.frame2child.insert(frame, node)
       }
       node.addToTotalWeight(weight)
 
@@ -611,7 +612,7 @@ export class CallTreeProfileBuilder extends Profile {
       } else {
         node = new CallTreeNode(frame, prevTop)
         prevTop.children.push(node)
-        prevTop.frame2child.set(frame, node)
+        prevTop.frame2child.insert(frame, node)
       }
       stack.push(node)
     }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,5 @@
+import DynamicTypedArray from 'dynamic-typed-array'
+
 export function lastOf<T>(ts: T[]): T | null {
   return ts[ts.length - 1] || null
 }
@@ -327,4 +329,32 @@ export function decodeBase64(encoded: string): Uint8Array {
   }
 
   return bytes
+}
+
+export class DynamicBitset {
+  private packs = new DynamicTypedArray<Uint32Array>(Uint32Array)
+  private nBits = 0
+
+  push(bit: boolean) {
+    this.nBits++
+    if (this.nBits > this.packs.size() << 5) {
+      this.packs.push(0)
+    }
+    if (bit) {
+      let at = this.nBits >>> 5
+      this.packs.set(at, this.packs.get(at) | (1 << (this.nBits & 31)))
+    }
+  }
+
+  get(index: number): boolean {
+    return !!(this.packs.get(index >>> 5) & (1 << (index & 31)))
+  }
+
+  set(index: number, bit: boolean) {
+    if (bit) {
+      this.packs.set(index >>> 5, this.packs.get(index >>> 5) | (1 << (index & 31)))
+    } else {
+      this.packs.set(index >>> 5, this.packs.get(index >>> 5) & ~(1 << (index & 31)))
+    }
+  }
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -336,14 +336,14 @@ export class DynamicBitset {
   private nBits = 0
 
   push(bit: boolean) {
-    this.nBits++
-    if (this.nBits > this.packs.size() << 5) {
+    if (this.nBits >>> 5 >= this.packs.size()) {
       this.packs.push(0)
     }
     if (bit) {
       let at = this.nBits >>> 5
       this.packs.set(at, this.packs.get(at) | (1 << (this.nBits & 31)))
     }
+    this.nBits++
   }
 
   get(index: number): boolean {

--- a/src/views/application.tsx
+++ b/src/views/application.tsx
@@ -169,34 +169,39 @@ export type ApplicationProps = {
   error: boolean
 }
 
+type LoaderWrapper = {fn: (() => Promise<ProfileGroup | null>) | null}
+
 export class Application extends StatelessComponent<ApplicationProps> {
-  private async loadProfile(loader: () => Promise<ProfileGroup | null>) {
+  private async loadProfile(lw: LoaderWrapper): Promise<ProfileGroup | null> {
     this.props.setError(false)
     this.props.setLoading(true)
     await new Promise(resolve => setTimeout(resolve, 0))
 
-    if (!this.props.glCanvas) return
+    if (!this.props.glCanvas) return null
 
     console.time('import')
 
     let profileGroup: ProfileGroup | null = null
     try {
-      profileGroup = await loader()
+      // @ts-ignore
+      profileGroup = await lw.fn()
     } catch (e) {
       console.log('Failed to load format', e)
       this.props.setError(true)
-      return
+      return null
     }
+
+    lw.fn = null
 
     // TODO(jlfwong): Make these into nicer overlays
     if (profileGroup == null) {
       alert('Unrecognized format! See documentation about supported formats.')
       this.props.setLoading(false)
-      return
+      return null
     } else if (profileGroup.profiles.length === 0) {
       alert("Successfully imported profile, but it's empty!")
       this.props.setLoading(false)
-      return
+      return null
     }
 
     if (this.props.hashParams.title) {
@@ -222,86 +227,101 @@ export class Application extends StatelessComponent<ApplicationProps> {
 
     console.timeEnd('import')
 
-    this.props.setProfileGroup(profileGroup)
-    this.props.setLoading(false)
+    return profileGroup
   }
 
   getStyle(): ReturnType<typeof getStyle> {
     return getStyle(this.props.theme)
   }
 
-  loadFromFile(file: File) {
-    this.loadProfile(async () => {
-      const profiles = await importProfilesFromFile(file)
-      if (profiles) {
-        for (let profile of profiles.profiles) {
-          if (!profile.getName()) {
-            profile.setName(file.name)
-          }
-        }
-        return profiles
-      }
-
-      if (this.props.profileGroup && this.props.activeProfileState) {
-        // If a profile is already loaded, it's possible the file being imported is
-        // a symbol map. If that's the case, we want to parse it, and apply the symbol
-        // mapping to the already loaded profile. This can be use to take an opaque
-        // profile and make it readable.
-        const reader = new FileReader()
-        const fileContentsPromise = new Promise<string>(resolve => {
-          reader.addEventListener('loadend', () => {
-            if (typeof reader.result !== 'string') {
-              throw new Error('Expected reader.result to be a string')
+  async loadReleasingFile(file: File) {
+    let profileGroup: ProfileGroup | null
+    {
+      profileGroup = await this.loadProfile({
+        fn: async () => {
+          const profiles = await importProfilesFromFile(file)
+          if (profiles) {
+            for (let profile of profiles.profiles) {
+              if (!profile.getName()) {
+                profile.setName(file.name)
+              }
             }
-            resolve(reader.result)
-          })
-        })
-        reader.readAsText(file)
-        const fileContents = await fileContentsPromise
-
-        let symbolRemapper: SymbolRemapper | null = null
-
-        const emscriptenSymbolRemapper = importEmscriptenSymbolRemapper(fileContents)
-        if (emscriptenSymbolRemapper) {
-          console.log('Importing as emscripten symbol map')
-          symbolRemapper = emscriptenSymbolRemapper
-        }
-
-        const jsSourceMapRemapper = await importJavaScriptSourceMapSymbolRemapper(
-          fileContents,
-          file.name,
-        )
-        if (!symbolRemapper && jsSourceMapRemapper) {
-          console.log('Importing as JavaScript source map')
-          symbolRemapper = jsSourceMapRemapper
-        }
-
-        if (symbolRemapper != null) {
-          return {
-            name: this.props.profileGroup.name || 'profile',
-            indexToView: this.props.profileGroup.indexToView,
-            profiles: this.props.profileGroup.profiles.map(profileState => {
-              // We do a shallow clone here to invalidate certain caches keyed
-              // on a reference to the profile group under the assumption that
-              // profiles are immutable. Symbol remapping is (at time of
-              // writing) the only exception to that immutability.
-              const p = profileState.profile.shallowClone()
-              p.remapSymbols(symbolRemapper!)
-              return p
-            }),
+            return profiles
           }
-        }
-      }
 
-      return null
-    })
+          if (this.props.profileGroup && this.props.activeProfileState) {
+            // If a profile is already loaded, it's possible the file being imported is
+            // a symbol map. If that's the case, we want to parse it, and apply the symbol
+            // mapping to the already loaded profile. This can be use to take an opaque
+            // profile and make it readable.
+            const reader = new FileReader()
+            const fileContentsPromise = new Promise<string>(resolve => {
+              reader.addEventListener('loadend', () => {
+                if (typeof reader.result !== 'string') {
+                  throw new Error('Expected reader.result to be a string')
+                }
+                resolve(reader.result)
+              })
+            })
+            reader.readAsText(file)
+            const fileContents = await fileContentsPromise
+
+            let symbolRemapper: SymbolRemapper | null = null
+
+            const emscriptenSymbolRemapper = importEmscriptenSymbolRemapper(fileContents)
+            if (emscriptenSymbolRemapper) {
+              console.log('Importing as emscripten symbol map')
+              symbolRemapper = emscriptenSymbolRemapper
+            }
+
+            const jsSourceMapRemapper = await importJavaScriptSourceMapSymbolRemapper(
+              fileContents,
+              file.name,
+            )
+            if (!symbolRemapper && jsSourceMapRemapper) {
+              console.log('Importing as JavaScript source map')
+              symbolRemapper = jsSourceMapRemapper
+            }
+
+            if (symbolRemapper != null) {
+              return {
+                name: this.props.profileGroup.name || 'profile',
+                indexToView: this.props.profileGroup.indexToView,
+                profiles: this.props.profileGroup.profiles.map(profileState => {
+                  // We do a shallow clone here to invalidate certain caches keyed
+                  // on a reference to the profile group under the assumption that
+                  // profiles are immutable. Symbol remapping is (at time of
+                  // writing) the only exception to that immutability.
+                  const p = profileState.profile.shallowClone()
+                  p.remapSymbols(symbolRemapper!)
+                  return p
+                }),
+              }
+            }
+          }
+
+          return null
+        },
+      })
+    }
+
+    if (profileGroup) {
+      this.props.setProfileGroup(profileGroup)
+      this.props.setLoading(false)
+    }
+  }
+
+  loadFromFile(file: File) {
+    this.loadReleasingFile(file)
   }
 
   loadExample = () => {
-    this.loadProfile(async () => {
-      const filename = 'perf-vertx-stacks-01-collapsed-all.txt'
-      const data = await fetch(exampleProfileURL).then(resp => resp.text())
-      return await importProfilesFromText(filename, data)
+    this.loadProfile({
+      fn: async () => {
+        const filename = 'perf-vertx-stacks-01-collapsed-all.txt'
+        const data = await fetch(exampleProfileURL).then(resp => resp.text())
+        return await importProfilesFromText(filename, data)
+      },
     })
   }
 
@@ -323,8 +343,10 @@ export class Application extends StatelessComponent<ApplicationProps> {
       ) {
         console.log('Importing as Instruments.app .trace file')
         const webkitDirectoryEntry: FileSystemDirectoryEntry = webkitEntry
-        this.loadProfile(async () => {
-          return await importFromFileSystemDirectoryEntry(webkitDirectoryEntry)
+        this.loadProfile({
+          fn: async () => {
+            return await importFromFileSystemDirectoryEntry(webkitDirectoryEntry)
+          },
         })
         return
       }
@@ -409,8 +431,10 @@ export class Application extends StatelessComponent<ApplicationProps> {
     const clipboardData = (ev as ClipboardEvent).clipboardData
     if (!clipboardData) return
     const pasted = clipboardData.getData('text')
-    this.loadProfile(async () => {
-      return await importProfilesFromText('From Clipboard', pasted)
+    this.loadProfile({
+      fn: async () => {
+        return await importProfilesFromText('From Clipboard', pasted)
+      },
     })
   }
 
@@ -436,13 +460,15 @@ export class Application extends StatelessComponent<ApplicationProps> {
         )
         return
       }
-      this.loadProfile(async () => {
-        const response: Response = await fetch(profileURL)
-        let filename = new URL(profileURL, window.location.href).pathname
-        if (filename.includes('/')) {
-          filename = filename.slice(filename.lastIndexOf('/') + 1)
-        }
-        return await importProfilesFromArrayBuffer(filename, await response.arrayBuffer())
+      this.loadProfile({
+        fn: async () => {
+          const response: Response = await fetch(profileURL)
+          let filename = new URL(profileURL, window.location.href).pathname
+          if (filename.includes('/')) {
+            filename = filename.slice(filename.lastIndexOf('/') + 1)
+          }
+          return await importProfilesFromArrayBuffer(filename, await response.arrayBuffer())
+        },
       })
     } else if (this.props.hashParams.localProfilePath) {
       // There isn't good cross-browser support for XHR of local files, even from
@@ -450,7 +476,8 @@ export class Application extends StatelessComponent<ApplicationProps> {
       // as a JavaScript file which will invoke a global function.
       ;(window as any)['speedscope'] = {
         loadFileFromBase64: (filename: string, base64source: string) => {
-          this.loadProfile(() => importProfilesFromBase64(filename, base64source))
+          // TODO (srogatch): is async missing here intnetionally? Or is it a bug?
+          this.loadProfile({fn: () => importProfilesFromBase64(filename, base64source)})
         },
       }
 

--- a/src/views/application.tsx
+++ b/src/views/application.tsx
@@ -236,6 +236,13 @@ export class Application extends StatelessComponent<ApplicationProps> {
     return getStyle(this.props.theme)
   }
 
+  handleProfileGroup(profileGroup: ProfileGroup | null) {
+    if (profileGroup) {
+      this.props.setProfileGroup(profileGroup)
+      this.props.setLoading(false)
+    }
+  }
+
   sleep(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms))
   }
@@ -331,10 +338,7 @@ export class Application extends StatelessComponent<ApplicationProps> {
 
     fileData = null
     fileName = null
-    if (profileGroup) {
-      this.props.setProfileGroup(profileGroup)
-      this.props.setLoading(false)
-    }
+    this.handleProfileGroup(profileGroup)
   }
 
   loadFromFile(file: File) {
@@ -348,6 +352,8 @@ export class Application extends StatelessComponent<ApplicationProps> {
         const data = await fetch(exampleProfileURL).then(resp => resp.text())
         return await importProfilesFromText(filename, data)
       },
+    }).then(profileGroup => {
+      this.handleProfileGroup(profileGroup)
     })
   }
 
@@ -373,6 +379,8 @@ export class Application extends StatelessComponent<ApplicationProps> {
           fn: async () => {
             return await importFromFileSystemDirectoryEntry(webkitDirectoryEntry)
           },
+        }).then(profileGroup => {
+          this.handleProfileGroup(profileGroup)
         })
         return
       }
@@ -461,6 +469,8 @@ export class Application extends StatelessComponent<ApplicationProps> {
       fn: async () => {
         return await importProfilesFromText('From Clipboard', pasted)
       },
+    }).then(profileGroup => {
+      this.handleProfileGroup(profileGroup)
     })
   }
 
@@ -495,6 +505,8 @@ export class Application extends StatelessComponent<ApplicationProps> {
           }
           return await importProfilesFromArrayBuffer(filename, await response.arrayBuffer())
         },
+      }).then(profileGroup => {
+        this.handleProfileGroup(profileGroup)
       })
     } else if (this.props.hashParams.localProfilePath) {
       // There isn't good cross-browser support for XHR of local files, even from
@@ -503,7 +515,11 @@ export class Application extends StatelessComponent<ApplicationProps> {
       ;(window as any)['speedscope'] = {
         loadFileFromBase64: (filename: string, base64source: string) => {
           // TODO (srogatch): is async missing here intnetionally? Or is it a bug?
-          this.loadProfile({fn: () => importProfilesFromBase64(filename, base64source)})
+          this.loadProfile({fn: () => importProfilesFromBase64(filename, base64source)}).then(
+            profileGroup => {
+              this.handleProfileGroup(profileGroup)
+            },
+          )
         },
       }
 


### PR DESCRIPTION
**The performance issue I identified is:**
A search in an array has a linear algorithmic complexity. The program was performing array searches upon each insertion of an event into its tree structure. This is especially affecting linear event structures, where there's almost one big array to search in, instead of events split across different nodes in a tree. So the complexity was quadratic: O(N*N) where N is the number of events in the trace. Obviously, for 200K events, 200K * 200K is 40 billion of operations, which was taking about 15 seconds on my laptop.

**Solution:**
Let's use a hashtable instead of a linear search in an array. One hashtable lookup is O(1) average case, meaning 200K events don't trigger a quadratic number of operations.